### PR TITLE
feature: active first li on init

### DIFF
--- a/features/reading-list/action.js
+++ b/features/reading-list/action.js
@@ -61,10 +61,6 @@ export const copyUrl = async () => {
 export const reactive = li => {
   activeLi().removeClass('active')
   li.addClass('active')
-  localStorage.setItem(
-    `${window.isHistoryPage ? 'local' : 'sync'}ActivatedLiId`,
-    li.attr('id')
-  )
 }
 
 export const scrollTo = (li, duration = 'fast') => {

--- a/features/reading-list/readingList.js
+++ b/features/reading-list/readingList.js
@@ -9,7 +9,7 @@ export async function setup() {
   resetEventListeners()
   await removeDeletedReadingItems()
   await initDomFromStorage()
-  activeLastActivatedLi()
+  activeFirstLi()
   changeIconOnMouseEnterLeave()
   updateStateOnMouseMove()
   doActionOnMouseClick()
@@ -51,19 +51,9 @@ async function initDomFromStorage() {
   readingList.children().slice(0, oldReadingItemsLength).remove()
 }
 
-function activeLastActivatedLi() {
-  const lastActivatedLiId = localStorage.getItem(
-    `${window.isHistoryPage ? 'local' : 'sync'}ActivatedLiId`
-  )
-
-  const li = lastActivatedLiId
-    ? $(`#${lastActivatedLiId}`)
-    : $('#reading-list li').first()
-
-  if (li.length !== 0) {
-    action.reactive(li)
-    action.scrollTo(li, 0)
-  }
+function activeFirstLi() {
+  const li = $('#reading-list li').first()
+  if (li.length !== 0) action.reactive(li)
 }
 
 function changeIconOnMouseEnterLeave() {


### PR DESCRIPTION
use this instead of active last activated li is that when moving mouse to the status bar, the active li will always be the last one in the viewport